### PR TITLE
Removed unnecessary calls to start() method.

### DIFF
--- a/multiply.js
+++ b/multiply.js
@@ -6,8 +6,6 @@ var result1 = document.querySelector('.result1');
 if (!!window.SharedWorker) {
   var myWorker = new SharedWorker("worker.js");
 
-  myWorker.port.start();
-
   first.onchange = function() {
 	myWorker.port.postMessage([first.value,second.value]);
 	console.log('Message posted to worker');

--- a/worker.js
+++ b/worker.js
@@ -5,6 +5,4 @@ onconnect = function(e) {
 	  var workerResult = 'Result: ' + (e.data[0] * e.data[1]);
 	  port.postMessage(workerResult);
 	}
-
-	port.start();
 }


### PR DESCRIPTION
Tested and confirmed that the `onmessage` event handler implicitly opens the port connection.
The `start()` method only needs to be called if the `message` event is wired up via `addEventListener()`.
